### PR TITLE
update delinquency counters to account for lender apr and protocol

### DIFF
--- a/src/market.ts
+++ b/src/market.ts
@@ -362,45 +362,97 @@ export class Market extends ContractWrapper<WildcatMarket> {
 
   get secondsBeforeDelinquency(): number {
     if (this.willBeDelinquent || this.totalDebts.eq(0)) return 0;
-    const interestPerSecondAddedToRequirements = this.totalSupply
-      .rayMul(this.effectiveBorrowerAPR)
+
+    const scaledBase = this.scaledTotalSupply.sub(this.scaledPendingWithdrawals);
+    if (scaledBase.lte(0)) return 0; // no supply after accounting for pending withdraws
+    const basePrincipal = this.underlyingToken.getAmount(rayMul(scaledBase, this.scaleFactor));
+
+    const baseAPRRay = bipToRay(this.annualInterestBips);
+    const protocolFeeAPRRay = bipMul(baseAPRRay, BigNumber.from(this.protocolFeeBips));
+    const delinquencyFeeAPRRay =
+      this.timeDelinquent > this.delinquencyGracePeriod
+        ? bipToRay(this.delinquencyFeeBips)
+        : BigNumber.from(0);
+
+    // lender APR portion
+    const lenderRequirementGrowthPerSecond = basePrincipal
+      .rayMul(baseAPRRay.add(delinquencyFeeAPRRay))
       .div(SECONDS_IN_365_DAYS)
       .bipMul(this.reserveRatioBips);
-    return this.liquidReserves
-      .sub(this.minimumReserves)
-      .div(interestPerSecondAddedToRequirements, true)
-      .raw.toNumber();
+
+    // protocol fee portion
+    const protocolRequirementGrowthPerSecond = basePrincipal
+      .rayMul(protocolFeeAPRRay)
+      .div(SECONDS_IN_365_DAYS);
+
+    const totalRequirementGrowthPerSecond = lenderRequirementGrowthPerSecond.add(
+      protocolRequirementGrowthPerSecond.raw
+    );
+    // essentially if  apr=0 and rr=0 then bips alone wont move us to delinquency
+    if (totalRequirementGrowthPerSecond.raw.isZero()) return Number.MAX_SAFE_INTEGER;
+
+    const buffer = this.liquidReserves.sub(this.minimumReserves);
+    if (buffer.raw.lte(0)) return 0; // we are delinquent
+    return buffer.div(totalRequirementGrowthPerSecond, true).raw.toNumber(); // seconds until the party
   }
 
   getSecondsBeforeDelinquencyForBorrowedAmount(borrowAmount: TokenAmount): number {
     if (this.isDelinquent || this.totalDebts.eq(0)) return 0;
-    const interestPerSecondAddedToRequirements = this.totalSupply
-      .rayMul(this.effectiveBorrowerAPR)
+    const scaledBase = this.scaledTotalSupply.sub(this.scaledPendingWithdrawals);
+    if (scaledBase.lte(0)) return 0;
+
+    const basePrincipal = this.underlyingToken.getAmount(rayMul(scaledBase, this.scaleFactor));
+    const baseAPRRay = bipToRay(this.annualInterestBips);
+    const protocolFeeAPRRay = bipMul(baseAPRRay, BigNumber.from(this.protocolFeeBips));
+    const delinquencyFeeAPRRay =
+      this.timeDelinquent > this.delinquencyGracePeriod
+        ? bipToRay(this.delinquencyFeeBips)
+        : BigNumber.from(0);
+
+    const lenderRequirementGrowthPerSecond = basePrincipal
+      .rayMul(baseAPRRay.add(delinquencyFeeAPRRay))
       .div(SECONDS_IN_365_DAYS)
       .bipMul(this.reserveRatioBips);
-    return this.liquidReserves
-      .sub(this.minimumReserves)
-      .sub(borrowAmount)
-      .div(interestPerSecondAddedToRequirements, true)
-      .raw.toNumber();
-  }
 
+    const protocolRequirementGrowthPerSecond = basePrincipal
+      .rayMul(protocolFeeAPRRay)
+      .div(SECONDS_IN_365_DAYS);
+
+    const totalRequirementGrowthPerSecond = lenderRequirementGrowthPerSecond.add(
+      protocolRequirementGrowthPerSecond.raw
+    );
+    if (totalRequirementGrowthPerSecond.raw.isZero()) return Number.MAX_SAFE_INTEGER;
+
+    const postBorrowBuffer = this.liquidReserves.sub(this.minimumReserves).sub(borrowAmount);
+    if (postBorrowBuffer.raw.lte(0)) return 0;
+    return postBorrowBuffer.div(totalRequirementGrowthPerSecond, true).raw.toNumber();
+  }
   /**
    * @dev Calculate token amount to be repayed by borrower for a given duration
    * to keep the market healthy.
    * @return token amount to be repayed
    **/
   repayRequiredForDuration(timeToPayInSeconds: number): TokenAmount {
-    const effectiveBorrowerAPR = bipMul(
-      bipToRay(this.annualInterestBips),
-      BIP.add(this.protocolFeeBips)
-    );
-
-    const interestPerSecond = this.totalSupply
-      .rayMul(effectiveBorrowerAPR)
+    const scaledBase = this.scaledTotalSupply.sub(this.scaledPendingWithdrawals);
+    if (scaledBase.lte(0)) return this.underlyingToken.getAmount(0);
+    const basePrincipal = this.underlyingToken.getAmount(rayMul(scaledBase, this.scaleFactor));
+    const baseAPRRay = bipToRay(this.annualInterestBips);
+    const protocolFeeAPRRay = bipMul(baseAPRRay, BigNumber.from(this.protocolFeeBips));
+    const delinquencyFeeAPRRay =
+      this.timeDelinquent > this.delinquencyGracePeriod
+        ? bipToRay(this.delinquencyFeeBips)
+        : BigNumber.from(0);
+    const lenderRequirementGrowthPerSecond = basePrincipal
+      .rayMul(baseAPRRay.add(delinquencyFeeAPRRay))
+      .div(SECONDS_IN_365_DAYS)
+      .bipMul(this.reserveRatioBips);
+    const protocolRequirementGrowthPerSecond = basePrincipal
+      .rayMul(protocolFeeAPRRay)
       .div(SECONDS_IN_365_DAYS);
-
-    return interestPerSecond.mul(timeToPayInSeconds);
+    const totalRequirementGrowthPerSecond = lenderRequirementGrowthPerSecond.add(
+      protocolRequirementGrowthPerSecond.raw
+    );
+    return totalRequirementGrowthPerSecond.mul(timeToPayInSeconds);
   }
 
   /**

--- a/src/market.ts
+++ b/src/market.ts
@@ -363,8 +363,7 @@ export class Market extends ContractWrapper<WildcatMarket> {
   get secondsBeforeDelinquency(): number {
     if (this.willBeDelinquent || this.totalDebts.eq(0)) return 0;
 
-    const scaledBase = this.scaledTotalSupply.sub(this.scaledPendingWithdrawals);
-    if (scaledBase.lte(0)) return 0; // no supply after accounting for pending withdraws
+    const scaledBase = this.scaledTotalSupply;
     const basePrincipal = this.underlyingToken.getAmount(rayMul(scaledBase, this.scaleFactor));
 
     const baseAPRRay = bipToRay(this.annualInterestBips);
@@ -398,8 +397,7 @@ export class Market extends ContractWrapper<WildcatMarket> {
 
   getSecondsBeforeDelinquencyForBorrowedAmount(borrowAmount: TokenAmount): number {
     if (this.isDelinquent || this.totalDebts.eq(0)) return 0;
-    const scaledBase = this.scaledTotalSupply.sub(this.scaledPendingWithdrawals);
-    if (scaledBase.lte(0)) return 0;
+    const scaledBase = this.scaledTotalSupply;
 
     const basePrincipal = this.underlyingToken.getAmount(rayMul(scaledBase, this.scaleFactor));
     const baseAPRRay = bipToRay(this.annualInterestBips);


### PR DESCRIPTION
attempt at updating delinquency timers to split between lender APR requirements and protocol fee requirements as per @d1ll0n 's comments

 
  - split interest calculations into lender portion (base + delinquency fees) and protocol fee portion
  - lender requirements still get multiplied by reserve ratio, protocol fees don't
  - added some special return for apr=0 and rr=0 so that on frontend we can use that to show a different message / nothing at all as its impossible to differentiate from other `return 0` 's
  - added same logic to the repay method also - i assume that needed updating too but if im wrong lmk