### PR TITLE
fix(lens): handle v2 lens on withdrawal

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wildcatfi/wildcat-sdk",
-  "version": "3.0.49-beta",
+  "version": "3.0.53-beta",
   "license": "MIT",
   "files": [
     "dist"

--- a/src/withdrawal-batch.ts
+++ b/src/withdrawal-batch.ts
@@ -2,7 +2,7 @@ import { BigNumber } from "ethers";
 import { Market } from "./market";
 import { TokenAmount, minTokenAmount } from "./token";
 import { WithdrawalBatchDataStructOutput } from "./typechain";
-import { getLensContract } from "./constants";
+import { getLensContract, getLensV2Contract, hasDeploymentAddress } from "./constants";
 import { LenderWithdrawalStatus } from "./withdrawal-status";
 import {
   MakeOptional,
@@ -19,6 +19,7 @@ import {
   parseWithdrawalRecord,
   rayMul
 } from "./utils";
+import { MarketVersion } from "./types";
 
 export enum BatchStatus {
   Pending = 0,
@@ -229,7 +230,11 @@ export class WithdrawalBatch {
   }
 
   static async getWithdrawalBatch(market: Market, expiry: number): Promise<WithdrawalBatch> {
-    const lens = getLensContract(market.chainId, market.provider);
+    const useLensV2 =
+      market.version === MarketVersion.V2 || !hasDeploymentAddress(market.chainId, "MarketLens");
+    const lens = useLensV2
+      ? getLensV2Contract(market.chainId, market.provider)
+      : getLensContract(market.chainId, market.provider);
     const data = await lens.getWithdrawalBatchData(market.address, expiry);
     return WithdrawalBatch.fromWithdrawalBatchData(market, data);
   }

--- a/src/withdrawal-status.ts
+++ b/src/withdrawal-status.ts
@@ -5,7 +5,12 @@ import {
   WithdrawalBatchLenderStatusStructOutput,
   WithdrawalBatchDataWithLenderStatusStructOutput
 } from "./typechain";
-import { SupportedChainId, getLensContract } from "./constants";
+import {
+  SupportedChainId,
+  getLensContract,
+  getLensV2Contract,
+  hasDeploymentAddress
+} from "./constants";
 import {
   WithdrawalExecutionRecord,
   WithdrawalRequestRecord,
@@ -14,6 +19,7 @@ import {
   parseWithdrawalRecord
 } from "./utils";
 import { WithdrawalBatch, BatchStatus } from "./withdrawal-batch";
+import { MarketVersion } from "./types";
 import {
   SubgraphLenderWithdrawalPropertiesFragment,
   SubgraphWithdrawalExecution,
@@ -118,7 +124,11 @@ export class LenderWithdrawalStatus {
     expiry: number,
     lender: string
   ): Promise<LenderWithdrawalStatus> {
-    const lens = getLensContract(market.chainId, market.provider);
+    const useLensV2 =
+      market.version === MarketVersion.V2 || !hasDeploymentAddress(market.chainId, "MarketLens");
+    const lens = useLensV2
+      ? getLensV2Contract(market.chainId, market.provider)
+      : getLensContract(market.chainId, market.provider);
     const batchData = await lens.getWithdrawalBatchDataWithLenderStatus(
       market.address,
       expiry,


### PR DESCRIPTION
queueing withdrawals on plasma would fail because sdk was only using v1 lens for `getWithdrawalBatchData` 

- added checks for `v1` or `v2` lens before querying

> i believe this never surfaced on Eth because the v1 lens still worked with v2 markets?