### PR TITLE
feat(wd-status): expose helpers and updateWith logic for termination

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wildcatfi/wildcat-sdk",
-  "version": "3.0.54-beta",
+  "version": "3.0.56-beta",
   "license": "MIT",
   "files": [
     "dist"

--- a/src/withdrawal-batch.ts
+++ b/src/withdrawal-batch.ts
@@ -99,6 +99,24 @@ export class WithdrawalBatch {
     return this.status === BatchStatus.Pending && this.expiry < Math.floor(Date.now() / 1000);
   }
 
+  get isConcluded(): boolean {
+    if (this.market.isClosed) return true;
+    return this.expiry <= Math.floor(Date.now() / 1000);
+  }
+
+  // unlike `status` which is purely timestamp-based, this accounts for market
+  // termination
+  // a batch with future expiry in a closed market returns Unpaid/Complete
+  // instead of Pending, since the cycle is effectively over
+  get effectiveStatus(): BatchStatus {
+    if (!this.isConcluded) {
+      return BatchStatus.Pending;
+    }
+    return this.scaledAmountBurned.eq(this.scaledTotalAmount)
+      ? BatchStatus.Complete
+      : BatchStatus.Unpaid;
+  }
+
   get normalizedAmountOwed(): TokenAmount {
     return this.normalizedTotalAmount.sub(this.normalizedAmountPaid);
   }

--- a/src/withdrawal-status.ts
+++ b/src/withdrawal-status.ts
@@ -72,6 +72,14 @@ export class LenderWithdrawalStatus {
     return this.batch.status;
   }
 
+  get isConcluded(): boolean {
+    return this.batch.isConcluded;
+  }
+
+  get effectiveStatus(): BatchStatus {
+    return this.batch.effectiveStatus;
+  }
+
   get normalizedTotalAmount(): TokenAmount {
     return this.normalizedAmountOwed.add(this.normalizedAmountWithdrawn);
   }
@@ -82,6 +90,15 @@ export class LenderWithdrawalStatus {
       data.normalizedAmountWithdrawn
     );
     this.normalizedAmountOwed = this.market.underlyingToken.getAmount(data.normalizedAmountOwed);
+
+    // recompute isCompleted based on updated values after a wd that 
+    // subgraph may not have updated yet 
+    this.isCompleted =
+      this.batch.status === BatchStatus.Complete &&
+      this.batch.expiry < Math.floor(Date.now() / 1000) &&
+      this.batch.normalizedAmountPaid
+        .mulDiv(data.scaledAmount, this.batch.scaledTotalAmount)
+        .eq(data.normalizedAmountWithdrawn);
   }
 
   get normalizedUnpaidAmount(): TokenAmount {


### PR DESCRIPTION
adds two new getters for market termination when determining batch state:
- `isConcluded`: true if market is closed OR batch expiry has passed
- `effectiveStatus`: returns Unpaid/Complete instead of Pending for batches in closed markets

also recomputes `isCompleted` in `updateWith` 